### PR TITLE
Removing strtotime() resolving empty expiration year select options

### DIFF
--- a/views/templates/front/payment_process.tpl
+++ b/views/templates/front/payment_process.tpl
@@ -100,7 +100,7 @@
                     
                     <div class="col-xs-4">
                         <select name="expiration_year" class="expiration-year form-control" id="expirationYear">
-                            {for $year=date('Y') to date('Y', strtotime('+ 19 years'))}
+                            {for $year=date('Y') to (date('Y') + 19)}
                                 <option value="{$year|intval}"
                                         {if isset($input['expiration_year']) && $input['expiration_year'] == $year}selected{/if}>
                                     {$year|escape:'htmlall':'UTF-8'}


### PR DESCRIPTION
THIS PULL RESOLVES THE ISSUE #2 
strtotime() function doesn't work in this case and doesn't generate any option for the expiration year select, so we replaced with a working solution.