### PR TITLE
fixed cvv popup on checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-LATEST_TAG = 4.0.8
+LATEST_TAG = 4.0.9
 build:
 	git archive --format=zip -o dist/cardinity-prestashop-$(LATEST_TAG).zip --prefix=cardinity/ HEAD

--- a/Readme.md
+++ b/Readme.md
@@ -63,9 +63,9 @@ Find the latest version of this extension here: https://github.com/cardinity/car
 <details show>
   <summary>For PrestaShop 1.7.x</summary>
   
-| Version | Description                                                   | Link                                                                                         |
-|---------|---------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| 4.0.8   | Added seperate translation lang for changing name on checkout | <a href="https://github.com/cardinity/cardinity-prestashop/releases/tag/v4.0.8">Download</a> |
+| Version | Description                 | Link                                                                                         |
+|---------|-----------------------------|----------------------------------------------------------------------------------------------|
+| 4.0.9   | Fixed CVV note on checkout | <a href="https://github.com/cardinity/cardinity-prestashop/releases/tag/v4.0.9">Download</a> |
 </details>
 
 <details show>

--- a/cardinity.php
+++ b/cardinity.php
@@ -55,7 +55,7 @@ class Cardinity extends PaymentModule
         $this->name = 'cardinity';
         $this->tab = 'payments_gateways';
         $this->ps_versions_compliancy = ['min' => '1.7', 'max' => _PS_VERSION_];
-        $this->version = '4.0.8';
+        $this->version = '4.0.9';
         $this->author = 'Cardinity';
         $this->module_key = 'dbc7d0655fa07a7fdafbc863104cc876';
 

--- a/controllers/front/cvv.php
+++ b/controllers/front/cvv.php
@@ -61,7 +61,7 @@ class CardinityCvvModuleFrontController extends ModuleFrontController
         $this->context->smarty->assign([
             'this_path' => $this->module->getPathUri(),
             'this_path_ssl' => Tools::getShopDomainSsl(true, true) . __PS_BASE_URI__ . 'modules/' . $this->module->name . '/',
-            'globalCSS' => _THEME_CSS_DIR_ . 'global.css',
+            'globalCSS' => _THEME_CSS_DIR_ . 'theme.css',
         ]);
 
         $this->setTemplate('module:cardinity/views/templates/front/cvv.tpl');

--- a/controllers/front/process.php
+++ b/controllers/front/process.php
@@ -59,6 +59,7 @@ class CardinityProcessModuleFrontController extends ModuleFrontController
     {
         parent::initContent();
 
+        $this->context->controller->addJqueryPlugin('fancybox');
         $order_id = (int) Tools::getValue('order_id');
         $payment_id = trim(Tools::getValue('MD'));
         $threeDSSessionData = trim(Tools::getValue('threeDSSessionData'));


### PR DESCRIPTION
![image](https://github.com/cardinity/cardinity-prestashop/assets/72551102/00684e2e-4870-40e1-b234-b59b49cc8988)
The cvv tips link was opening a link instead of the popup from missing js.  also there was js errors due to missing library calls.  Refreshing page removes checkout info and user has to start again if accidentally clicked.