### PR TITLE
PHP-528 updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-LATEST_TAG = 4.0.10
+LATEST_TAG = 4.1.0
 build:
 	git archive --format=zip -o dist/cardinity-prestashop-$(LATEST_TAG).zip --prefix=cardinity/ HEAD

--- a/cardinity.php
+++ b/cardinity.php
@@ -61,7 +61,7 @@ class Cardinity extends PaymentModule
         $this->name = 'cardinity';
         $this->tab = 'payments_gateways';
         $this->ps_versions_compliancy = ['min' => '1.7', 'max' => _PS_VERSION_];
-        $this->version = '4.0.10';
+        $this->version = '4.1.0';
         $this->author = 'Cardinity';
         $this->module_key = 'dbc7d0655fa07a7fdafbc863104cc876';
 
@@ -545,6 +545,7 @@ class Cardinity extends PaymentModule
             'description' => 'PS' . $params['cart']->id,
             'project_id' => Configuration::get('CARDINITY_PROJECT_KEY'),
             'return_url' => $this->context->link->getModuleLink($this->name, 'return'),
+            'notification_url' => $this->context->link->getModuleLink($this->name, 'notify'),
         ];
         if($customer->email){
             $attributes['email_address'] = $customer->email;
@@ -600,6 +601,11 @@ class Cardinity extends PaymentModule
                     'name' => 'return_url',
                     'type' => 'hidden',
                     'value' => $attributes['return_url'],
+                ],
+                'notification_url' => [
+                    'name' => 'notification_url',
+                    'type' => 'hidden',
+                    'value' => $attributes['notification_url'],
                 ],
                 'signature' => [
                     'name' => 'signature',

--- a/views/templates/front/redirect_external.tpl
+++ b/views/templates/front/redirect_external.tpl
@@ -29,6 +29,7 @@
             <input type="hidden" name="email_address" value="{$attributes['email_address']|escape:'htmlall':'UTF-8'}" />
 			<input type="hidden" name="project_id" value="{$attributes['project_id']|escape:'htmlall':'UTF-8'}" />
 			<input type="hidden" name="return_url" value="{$attributes['return_url']|escape:'htmlall':'UTF-8'}" />
+            <input type="hidden" name="notification_url" value="{$attributes['notification_url']|escape:'htmlall':'UTF-8'}" />
 			<input type="hidden" name="signature" value="{$attributes['signature']|escape:'htmlall':'UTF-8'}" />
       </form>
 


### PR DESCRIPTION
Added external notification endpoint for prestashop external checkout.

Had to setup a dummy shop with https and no .htaccess password

test frontend
https://shsdev.xyz/cardinity/ps/

order logs can verify if order was marked paid via notification or callback